### PR TITLE
Fix: allow user to see cards before exiting

### DIFF
--- a/picker.py
+++ b/picker.py
@@ -77,6 +77,7 @@ def run_now():
     card_catalog = build_card_list(set_list)    #Builds list of all cards in sets
     cards = pick_cards(card_catalog)            #Picks 10 cards from card list
     print(cards)
+    input("Press ENTER to exit.")
     return
 
 if __name__ == '__main__':

--- a/user_sets.txt
+++ b/user_sets.txt
@@ -1,1 +1,1 @@
-[[0, "Dominion"], [1, "Intrigue"], [2, "Seaside"], [4, "Prosperity"], [5, "Cornucopia"], [7, "Dark Ages"], [8, "Guilds"], [9, "Adventures"]]
+[[0, "Dominion"], [1, "Intrigue"], [2, "Seaside"], [4, "Prosperity"], [6, "Hinterlands"], [8, "Guilds"], [9, "Adventures"]]


### PR DESCRIPTION
Added line to leave terminal open until user hits ENTER so they can see
the selected cards.
